### PR TITLE
Add favorite bus stop feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,15 +21,18 @@ BackEnd - https://github.com/deepak252/Bus-Tracking-Backend
 - The app retrieves and displays a list of available bus routes and associated stops from the backend database.
 - Users can search for specific routes, view route details, and select their desired bus stops.
 
-**5. Estimated Arrival Times:**
+**5. Favorite Bus Stops:**
+- Mark frequently used stops as favorites for quick access across the app.
+
+**6. Estimated Arrival Times:**
 - The app calculates and displays estimated arrival times for buses at designated stops.
 - Users can view the estimated arrival times for their selected bus stops to plan their journeys accordingly.
 
-**6. Bus Schedule and Timetable:**
+**7. Bus Schedule and Timetable:**
 - The app retrieves the latest bus schedules and timetables from the backend system.
 - Users can access the schedule information to check the departure and arrival times of buses at different stops.
   
-**7. User Profile Management:**
+**8. User Profile Management:**
 - Users can check their profiles within the app.
   
 **9. Interactive Maps:**

--- a/app/src/main/java/com/example/bustrackingapp/feature_bus_stop/di/BusStopModule.kt
+++ b/app/src/main/java/com/example/bustrackingapp/feature_bus_stop/di/BusStopModule.kt
@@ -7,6 +7,7 @@ import com.example.bustrackingapp.feature_bus_stop.domain.use_case.BusStopUseCas
 import com.example.bustrackingapp.feature_bus_stop.domain.use_case.GetAllBusStopsUseCase
 import com.example.bustrackingapp.feature_bus_stop.domain.use_case.GetBusStopUseCase
 import com.example.bustrackingapp.feature_bus_stop.domain.use_case.GetNearbyBusStopsUseCase
+import com.example.bustrackingapp.feature_bus_stop.domain.use_case.ToggleFavoriteUseCase
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -34,14 +35,22 @@ object BusStopModule {
 
     @Provides
     @Singleton
+    fun provideToggleFavoriteUseCase(
+        prefs: com.example.bustrackingapp.core.domain.repository.UserPrefsRepository
+    ): ToggleFavoriteUseCase = ToggleFavoriteUseCase(prefs)
+
+    @Provides
+    @Singleton
     fun provideBusStopUseCases(
         getAllBusStopsUseCase: GetAllBusStopsUseCase,
         getNearbyBusStopsUseCase: GetNearbyBusStopsUseCase,
         getBusStopUseCase: GetBusStopUseCase,
+        toggleFavoriteUseCase: ToggleFavoriteUseCase,
     ) : BusStopUseCases = BusStopUseCases(
         getAllBusStops = getAllBusStopsUseCase,
         getNearbyBusStops = getNearbyBusStopsUseCase,
         getBusStop = getBusStopUseCase,
+        toggleFavorite = toggleFavoriteUseCase,
     )
 
 }

--- a/app/src/main/java/com/example/bustrackingapp/feature_bus_stop/domain/use_case/BusStopUseCases.kt
+++ b/app/src/main/java/com/example/bustrackingapp/feature_bus_stop/domain/use_case/BusStopUseCases.kt
@@ -1,8 +1,8 @@
 package com.example.bustrackingapp.feature_bus_stop.domain.use_case
 
 data class BusStopUseCases(
-    val getAllBusStops : GetAllBusStopsUseCase,
+    val getAllBusStops: GetAllBusStopsUseCase,
     val getNearbyBusStops: GetNearbyBusStopsUseCase,
-    val getBusStop : GetBusStopUseCase,
-    val toggleFavorite: ToggleFavoriteUseCase    // ← new
+    val getBusStop: GetBusStopUseCase,
+    val toggleFavorite: ToggleFavoriteUseCase
 )

--- a/app/src/main/java/com/example/bustrackingapp/feature_bus_stop/domain/use_case/ToggleFavoriteUseCase.kt
+++ b/app/src/main/java/com/example/bustrackingapp/feature_bus_stop/domain/use_case/ToggleFavoriteUseCase.kt
@@ -1,0 +1,12 @@
+package com.example.bustrackingapp.feature_bus_stop.domain.use_case
+
+import com.example.bustrackingapp.core.domain.repository.UserPrefsRepository
+import javax.inject.Inject
+
+class ToggleFavoriteUseCase @Inject constructor(
+    private val prefs: UserPrefsRepository
+) {
+    suspend operator fun invoke(stopNo: String) = prefs.toggleFavoriteStop(stopNo)
+
+    fun favorites() = prefs.getFavoriteStops()
+}

--- a/app/src/main/java/com/example/bustrackingapp/feature_bus_stop/presentation/all_stops/BusStopsViewModel.kt
+++ b/app/src/main/java/com/example/bustrackingapp/feature_bus_stop/presentation/all_stops/BusStopsViewModel.kt
@@ -2,9 +2,8 @@ package com.example.bustrackingapp.feature_bus_stop.presentation.all_stops
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.bustrackingapp.core.domain.repository.UserPrefsRepository
 import com.example.bustrackingapp.core.util.Resource
-import com.example.bustrackingapp.feature_bus_stop.domain.use_case.GetAllBusStopsUseCase
+import com.example.bustrackingapp.feature_bus_stop.domain.use_case.BusStopUseCases
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
@@ -19,8 +18,7 @@ data class BusStopsUiState(
 
 @HiltViewModel
 class BusStopsViewModel @Inject constructor(
-  private val busStopsUseCase: GetAllBusStopsUseCase,
-  private val prefs: UserPrefsRepository
+    private val busStopUseCases: BusStopUseCases
 ) : ViewModel() {
 
   // 1) UI state for the list
@@ -28,7 +26,7 @@ class BusStopsViewModel @Inject constructor(
   val uiState: StateFlow<BusStopsUiState> = _uiState
 
   // 2) Expose the favorites Flow straight from DataStore
-  val favoriteStops: Flow<Set<String>> = prefs.getFavoriteStops()
+  val favoriteStops: Flow<Set<String>> = busStopUseCases.toggleFavorite.favorites()
 
   init {
     getAllBusStops(isLoading = true)
@@ -36,7 +34,7 @@ class BusStopsViewModel @Inject constructor(
 
   /** Fetch all stops and mark favorites */
   fun getAllBusStops(isLoading: Boolean = false, isRefreshing: Boolean = false) {
-    busStopsUseCase()
+    busStopUseCases.getAllBusStops()
       .onStart { _uiState.update { it.copy(isLoading = isLoading, error = null) } }
       .onEach { result ->
         _uiState.update { state ->
@@ -69,7 +67,7 @@ class BusStopsViewModel @Inject constructor(
   /** Toggle a stop in favorites, then refresh the list */
   fun toggleFavorite(stopNo: String) {
     viewModelScope.launch {
-      prefs.toggleFavoriteStop(stopNo)
+      busStopUseCases.toggleFavorite(stopNo)
       getAllBusStops(isRefreshing = true)
     }
   }

--- a/app/src/main/java/com/example/bustrackingapp/feature_bus_stop/presentation/stop_details/StopDetailsScreen.kt
+++ b/app/src/main/java/com/example/bustrackingapp/feature_bus_stop/presentation/stop_details/StopDetailsScreen.kt
@@ -9,8 +9,14 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.outlined.FavoriteBorder
 import androidx.compose.material3.Divider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.ui.graphics.Color
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Snackbar
@@ -59,12 +65,22 @@ fun StopDetailsScreen(
 
     Scaffold(
         topBar = {
+            val isFav = stopDetailsViewModel.uiState.isFavorite
             TopAppBar(
                 title = {
                     Text(
                         "Stop Details",
                         style = MaterialTheme.typography.headlineSmall
                     )
+                },
+                actions = {
+                    IconButton(onClick = { stopDetailsViewModel.toggleFavorite() }) {
+                        Icon(
+                            imageVector = if (isFav) Icons.Filled.Favorite else Icons.Outlined.FavoriteBorder,
+                            contentDescription = if (isFav) "Unfavorite stop" else "Favorite stop",
+                            tint = if (isFav) Color.Red else MaterialTheme.colorScheme.onBackground
+                        )
+                    }
                 }
             )
         },

--- a/app/src/main/java/com/example/bustrackingapp/feature_bus_stop/presentation/stop_details/StopDetailsUiState.kt
+++ b/app/src/main/java/com/example/bustrackingapp/feature_bus_stop/presentation/stop_details/StopDetailsUiState.kt
@@ -7,6 +7,7 @@ import com.example.bustrackingapp.feature_bus_stop.domain.model.BusStopWithRoute
 data class StopDetailsUiState(
     val stop : BusStopWithRoutes?=null,
     val buses : List<BusWithRoute> = emptyList(),
+    val isFavorite: Boolean = false,
     val isLoading : Boolean = false,
     val isRefreshing : Boolean = false,
     val error : String?=null

--- a/app/src/main/java/com/example/bustrackingapp/feature_bus_stop/presentation/stop_details/StopDetailsViewModel.kt
+++ b/app/src/main/java/com/example/bustrackingapp/feature_bus_stop/presentation/stop_details/StopDetailsViewModel.kt
@@ -8,19 +8,27 @@ import androidx.lifecycle.viewModelScope
 import com.example.bustrackingapp.core.util.Resource
 import com.example.bustrackingapp.feature_bus.domain.use_cases.GetBusesForStopUseCase
 import com.example.bustrackingapp.feature_bus_stop.domain.use_case.GetBusStopUseCase
+import com.example.bustrackingapp.feature_bus_stop.domain.use_case.ToggleFavoriteUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 
 @HiltViewModel
 class StopDetailsViewModel @Inject constructor(
     private val getBusStopUseCase: GetBusStopUseCase,
-    private val getBusesForStopUseCase: GetBusesForStopUseCase
+    private val getBusesForStopUseCase: GetBusesForStopUseCase,
+    private val toggleFavoriteUseCase: ToggleFavoriteUseCase
 ) : ViewModel(){
     var uiState by mutableStateOf(StopDetailsUiState())
         private set
+
+    private val favoriteStops = toggleFavoriteUseCase.favorites()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptySet())
 
     init {
 //        viewModelScope.launch {
@@ -32,19 +40,37 @@ class StopDetailsViewModel @Inject constructor(
         if(uiState.isLoading || uiState.isRefreshing){
             return
         }
-        getBusStopUseCase(stopNo).onEach { result->
-            uiState = when(result){
-                is Resource.Success ->{
-                    uiState.copy(stop = result.data, isLoading = false, isRefreshing = false, error = null)
+        getBusStopUseCase(stopNo).onEach { result ->
+            uiState = when (result) {
+                is Resource.Success -> {
+                    val fav = favoriteStops.value.contains(result.data?.stopNo)
+                    uiState.copy(
+                        stop = result.data,
+                        isLoading = false,
+                        isRefreshing = false,
+                        error = null,
+                        isFavorite = fav
+                    )
                 }
-                is Resource.Error ->{
-                    uiState.copy(error = result.message, isLoading = false, isRefreshing = false)
-                }
-                is Resource.Loading ->{
-                    uiState.copy(isLoading = isLoading, isRefreshing = isRefreshing, error = null)
-                }
+                is Resource.Error -> uiState.copy(
+                    error = result.message,
+                    isLoading = false,
+                    isRefreshing = false
+                )
+                is Resource.Loading -> uiState.copy(
+                    isLoading = isLoading,
+                    isRefreshing = isRefreshing,
+                    error = null
+                )
             }
         }
             .launchIn(viewModelScope)
+    }
+
+    fun toggleFavorite() {
+        val stopNo = uiState.stop?.stopNo ?: return
+        viewModelScope.launch {
+            toggleFavoriteUseCase(stopNo)
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add `ToggleFavoriteUseCase` for persisting favorites
- expose use case via `BusStopModule`
- use new use case inside stop-related view models
- show favorite icon in stop details screen
- document favorite feature in README

## Testing
- `./gradlew --version`
- `./gradlew test --dry-run` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_684d01a9f3a8832cb3f3dda7ab7bb098