### PR TITLE
Fix map zoom and remove routes header

### DIFF
--- a/app/src/main/java/com/example/bustrackingapp/feature_bus_stop/presentation/stop_details/StopDetailsScreen.kt
+++ b/app/src/main/java/com/example/bustrackingapp/feature_bus_stop/presentation/stop_details/StopDetailsScreen.kt
@@ -167,10 +167,6 @@ fun BusStopDetailsContainer(
 
             Spacer(Modifier.height(24.dp))
 
-            Text(
-                "Routes:",
-                style = MaterialTheme.typography.titleSmall
-            )
             Column {
                 busStop.routes.forEach { route ->
                     BusRouteTile(
@@ -195,7 +191,7 @@ private fun StopLocationMap(busStop: BusStopWithRoutes) {
 
     LaunchedEffect(latLng) {
         cameraPositionState.move(
-            CameraUpdateFactory.newLatLngZoom(latLng, 16f)
+            CameraUpdateFactory.newLatLngZoom(latLng, 15f)
         )
     }
 


### PR DESCRIPTION
## Summary
- remove the **Routes:** label from the stop details screen
- use Google Maps Compose camera zoom level 15

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e2d32e7d0832ca4ceb856e03addeb