### PR TITLE
Remove search route and enhance map

### DIFF
--- a/app/src/main/java/com/example/bustrackingapp/core/domain/models/Location.kt
+++ b/app/src/main/java/com/example/bustrackingapp/core/domain/models/Location.kt
@@ -1,8 +1,9 @@
 package com.example.bustrackingapp.core.domain.models
 
 data class Location(
-    val _id: String,
-    val lat: Double,
-    val lng: Double,
-    val address: String?=null
+    val _id: String? = null,
+    val lat: Double = 0.0,
+    val lng: Double = 0.0,
+    val coordinates: List<Double>? = null,
+    val address: String? = null
 )

--- a/app/src/main/java/com/example/bustrackingapp/feature_bus_routes/presentation/bus_routes/BusRoutesScreen.kt
+++ b/app/src/main/java/com/example/bustrackingapp/feature_bus_routes/presentation/bus_routes/BusRoutesScreen.kt
@@ -10,8 +10,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.Divider
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -27,14 +25,11 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalFocusManager
-import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.example.bustrackingapp.R
 import com.example.bustrackingapp.core.presentation.components.CustomLoadingIndicator
-import com.example.bustrackingapp.core.presentation.components.CustomTextField
 import com.example.bustrackingapp.core.presentation.components.RefreshContainer
 import com.example.bustrackingapp.core.util.LoggerUtil
 import com.example.bustrackingapp.feature_bus_routes.domain.models.BusRouteWithStops
@@ -108,18 +103,11 @@ fun BusRoutesScreen(
                 .fillMaxSize()
         ) {
             BusRouteList(
-                busRoutes = {busRoutesViewModel.uiState.busRoutes},
-                searchInput = {busRoutesViewModel.uiState.searchInput},
-                onSearchInputChange = busRoutesViewModel::onSearchInputChange,
-                isLoading = {busRoutesViewModel.uiState.isLoading},
-                isRefreshing = {busRoutesViewModel.uiState.isRefreshing},
+                busRoutes = { busRoutesViewModel.uiState.busRoutes },
+                isLoading = { busRoutesViewModel.uiState.isLoading },
+                isRefreshing = { busRoutesViewModel.uiState.isRefreshing },
                 onRefresh = busRoutesViewModel::getAllBusRoutes,
-                onRouteItemClick = onRouteItemClick,
-                onClearFocus = { focusManager.clearFocus() },
-                onClearSearchClick = {
-                    busRoutesViewModel.onSearchInputChange("")
-                    focusManager.clearFocus()
-                }
+                onRouteItemClick = onRouteItemClick
             )
         }
     }
@@ -127,44 +115,22 @@ fun BusRoutesScreen(
 
 @Composable
 private fun BusRouteList(
-    busRoutes : ()->List<BusRouteWithStops>,
-    searchInput : ()->String,
-    onSearchInputChange : (String)->Unit,
-    isLoading : ()->Boolean,
-    isRefreshing : ()->Boolean,
-    onRefresh : (isLoading : Boolean, isRefreshing : Boolean)->Unit,
-    onRouteItemClick : (String)->Unit,
-    onClearFocus : ()->Unit,
-    onClearSearchClick : ()->Unit
+    busRoutes: () -> List<BusRouteWithStops>,
+    isLoading: () -> Boolean,
+    isRefreshing: () -> Boolean,
+    onRefresh: (isLoading: Boolean, isRefreshing: Boolean) -> Unit,
+    onRouteItemClick: (String) -> Unit
 ){
     if(isLoading()){
         return CustomLoadingIndicator()
     }
 
-    Column() {
-        CustomTextField(
-            value = searchInput,
-            onValueChange = onSearchInputChange,
-            hintText = "Search Route",
-            labelText = "Search Route",
-            onClearFocus = onClearFocus,
-            modifier = Modifier.padding(
-                start = 12.dp, end=12.dp, bottom = 12.dp
-            ),
-            radius = 100,
-            leadingIcon = Icons.Default.Search,
-            trailingIcon = if(searchInput().isNotEmpty())
-                ImageVector.vectorResource(id = R.drawable.baseline_cancel_24)
-                    else null,
-            onTrailingIconClick = onClearSearchClick,
-        )
+    Column {
         if(busRoutes().isEmpty())
             RefreshContainer(
                 modifier = Modifier.fillMaxHeight(0.4f),
                 message = "No Bus Routes Found!",
-                onRefresh = if(searchInput().isEmpty()) {
-                    { onRefresh(false, true) }
-                } else null
+                onRefresh = { onRefresh(false, true) }
             )
         else
             SwipeRefresh(

--- a/app/src/main/java/com/example/bustrackingapp/feature_bus_routes/presentation/bus_routes/BusRoutesUiState.kt
+++ b/app/src/main/java/com/example/bustrackingapp/feature_bus_routes/presentation/bus_routes/BusRoutesUiState.kt
@@ -4,8 +4,7 @@ import com.example.bustrackingapp.feature_bus_routes.domain.models.BusRouteWithS
 
 data class BusRoutesUiState(
     val allRoutes : List<BusRouteWithStops> = emptyList(),
-    val busRoutes : List<BusRouteWithStops> = emptyList(), // search result
-    val searchInput : String = "",
+    val busRoutes : List<BusRouteWithStops> = emptyList(),
     val isLoading : Boolean = false,
     val isRefreshing : Boolean = false,
     val error : String?=null

--- a/app/src/main/java/com/example/bustrackingapp/feature_bus_routes/presentation/bus_routes/BusRoutesViewModel.kt
+++ b/app/src/main/java/com/example/bustrackingapp/feature_bus_routes/presentation/bus_routes/BusRoutesViewModel.kt
@@ -1,12 +1,11 @@
 package com.example.bustrackingapp.feature_bus_routes.presentation.bus_routes
 
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.bustrackingapp.core.util.Resource
-import com.example.bustrackingapp.core.util.ValidationUtil
 import com.example.bustrackingapp.feature_bus_routes.domain.use_case.BusRouteUseCases
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.launchIn
@@ -23,25 +22,6 @@ class BusRoutesViewModel @Inject constructor(
     init {
         getAllBusRoutes(isLoading = true)
     }
-
-    fun onSearchInputChange(newVal : String){
-        uiState = uiState.copy(
-            searchInput = newVal
-        )
-        val searchInput = newVal.trim()
-        uiState = if(searchInput.isNotEmpty()){
-            uiState.copy(
-                busRoutes = uiState.allRoutes.filter {
-                    it.routeNo.contains(searchInput, true)
-                            || it.name.contains(searchInput, true)
-                }
-            )
-        }else{
-            uiState.copy(busRoutes = uiState.allRoutes)
-        }
-
-    }
-
     fun getAllBusRoutes(isLoading : Boolean = false, isRefreshing : Boolean = false){
         if(uiState.isLoading || uiState.isRefreshing){
             return


### PR DESCRIPTION
## Summary
- drop unused search field on Bus Routes screen
- simplify BusRoutes state and ViewModel
- show shuttle route polyline with markers in Stop Details map
- add placeholder bus location marker for future real-time data

## Testing
- `./gradlew test --no-daemon` *(fails: unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_684e2d32e7d0832ca4ceb856e03addeb